### PR TITLE
Add color picker to the badge creator color options

### DIFF
--- a/components/shared.tsx
+++ b/components/shared.tsx
@@ -39,14 +39,24 @@ export const Dropdown = ({ id, options, label, setBadgeProps, badgeProps }) => (
 export const BadgeInput = ({ id, label, setBadgeProps, badgeProps }) => (
   <label className="flex items-center justify-between text-sm my-2">
     <div className="mr-6">{label}</div>
-    <input
-      className="border border-gray-200 rounded py-2 px-4 flex-none w-36"
-      placeholder="#333333"
-      value={badgeProps[id]}
-      onChange={(e: any) =>
-        setBadgeProps({ ...badgeProps, [id]: e.target.value })
-      }
-    ></input>
+    <div className="border border-gray-200 rounded flex w-36 items-center justify-stretch">
+      <input
+        className="py-2 px-4 flex-initial w-9/12 pr-0"
+        placeholder="#333333"
+        value={badgeProps[id]}
+        onChange={(e: any) =>
+          setBadgeProps({ ...badgeProps, [id]: e.target.value })
+        }
+      />
+      <input
+        type="color"
+        className="flex-initial p-0 pr-4 bg-transparent"
+        value={badgeProps[id]}
+        onChange={(e: any) =>
+          setBadgeProps({ ...badgeProps, [id]: e.target.value })
+        }
+      />
+    </div>
   </label>
 );
 


### PR DESCRIPTION
Gives the option to use their browser's color picker as well as typing in the color.

<img width="665" alt="image" src="https://user-images.githubusercontent.com/7832610/103139217-8e88b380-469f-11eb-92f0-8c61111bfcb4.png">


`<input type="color">` [browser compatability](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/color):

<img width="1007" alt="image" src="https://user-images.githubusercontent.com/7832610/103139234-d1e32200-469f-11eb-9446-002c36320809.png">
